### PR TITLE
Add image import context and integrate with workspace

### DIFF
--- a/src/components/Header/ActionPopups.js
+++ b/src/components/Header/ActionPopups.js
@@ -1,12 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import './ActionPopups.css';
+import { ImageContext } from '../../context/ImageContext';
 
 const ActionPopups = ({ activePopup, setActivePopup }) => {
-  const [importSettings, setImportSettings] = useState({
-    autoDetect: true,
-    enhance: true,
-    batch: false
-  });
+const [importSettings, setImportSettings] = useState({
+  autoDetect: true,
+  enhance: true,
+  batch: false
+});
+
+  const [selectedFile, setSelectedFile] = useState(null);
+
+  const { setImageSrc } = useContext(ImageContext);
   
   const [exportSettings, setExportSettings] = useState({
     format: 'pdf',
@@ -30,8 +35,17 @@ const ActionPopups = ({ activePopup, setActivePopup }) => {
   const closePopup = () => setActivePopup(null);
 
   const handleImport = () => {
-    console.log('Import with settings:', importSettings);
-    closePopup();
+    if (selectedFile) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setImageSrc(reader.result);
+        closePopup();
+      };
+      reader.readAsDataURL(selectedFile);
+    } else {
+      console.log('Import with settings:', importSettings);
+      closePopup();
+    }
   };
 
   const handleExport = () => {
@@ -56,7 +70,7 @@ const ActionPopups = ({ activePopup, setActivePopup }) => {
               hidden 
               accept=".dcm,.jpg,.jpeg,.png,.tiff,.tif"
               multiple
-              onChange={(e) => console.log('Files selected:', e.target.files)}
+              onChange={(e) => setSelectedFile(e.target.files[0])}
             />
             <svg width="48" height="48" viewBox="0 0 24 24" fill="none">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/components/Workspace/Workspace.css
+++ b/src/components/Workspace/Workspace.css
@@ -150,3 +150,9 @@
 .upload-icon svg {
   animation: float 3s ease-in-out infinite;
 }
+
+.workspace-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}

--- a/src/components/Workspace/Workspace.js
+++ b/src/components/Workspace/Workspace.js
@@ -1,8 +1,11 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import ImageEditingToolbar from './ImageEditingToolbar';
 import './Workspace.css';
+import { ImageContext } from '../../context/ImageContext';
 
 const Workspace = () => {
+  const { imageSrc } = useContext(ImageContext);
+
   return (
     <main className="workspace">
       <div className="workspace-header">
@@ -33,28 +36,32 @@ const Workspace = () => {
       </div>
       
       <div className="upload-area">
-        <div className="upload-content">
-          <div className="upload-icon">
-            <svg width="64" height="64" viewBox="0 0 24 24" fill="none">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <polyline points="17 8 12 3 7 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
+        {imageSrc ? (
+          <img src={imageSrc} alt="Uploaded" className="workspace-image" />
+        ) : (
+          <div className="upload-content">
+            <div className="upload-icon">
+              <svg width="64" height="64" viewBox="0 0 24 24" fill="none">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <polyline points="17 8 12 3 7 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </div>
+            <h2>Upload Medical Image</h2>
+            <p>Drag and drop your X-ray, MRI, or CT scan here, or click to browse</p>
+            <div className="supported-formats">
+              <span>Supported formats: JPEG, PNG, DICOM, TIFF</span>
+            </div>
+            <button className="upload-button">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <polyline points="17 8 12 3 7 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+              Select Image
+            </button>
           </div>
-          <h2>Upload Medical Image</h2>
-          <p>Drag and drop your X-ray, MRI, or CT scan here, or click to browse</p>
-          <div className="supported-formats">
-            <span>Supported formats: JPEG, PNG, DICOM, TIFF</span>
-          </div>
-          <button className="upload-button">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <polyline points="17 8 12 3 7 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            Select Image
-          </button>
-        </div>
+        )}
       </div>
       
       <ImageEditingToolbar />

--- a/src/context/ImageContext.js
+++ b/src/context/ImageContext.js
@@ -1,0 +1,16 @@
+import React, { createContext, useState } from 'react';
+
+export const ImageContext = createContext({
+  imageSrc: null,
+  setImageSrc: () => {}
+});
+
+export const ImageProvider = ({ children }) => {
+  const [imageSrc, setImageSrc] = useState(null);
+
+  return (
+    <ImageContext.Provider value={{ imageSrc, setImageSrc }}>
+      {children}
+    </ImageContext.Provider>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ImageProvider } from './context/ImageContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ImageProvider>
+      <App />
+    </ImageProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- create `ImageContext` to share uploaded image between components
- wire up provider in `index.js`
- load selected image from Import popup and store in context
- display uploaded image in `Workspace`
- style new `workspace-image` element

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fcea8554832682280472f59db4f9